### PR TITLE
Drop console in production builds.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,8 +53,6 @@ module.exports = {
 
     'quasar/check-valid-props': 'warn',
 
-    // allow console.log during development only
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     // allow debugger during development only
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
   }

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -6,7 +6,11 @@ module.exports = function (ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://quasar.dev/quasar-cli/cli-documentation/boot-files
-    boot: ['i18n', 'axios', { path: 'gdpr', server: false }],
+    boot: [
+      'i18n',
+      'axios',
+      { path: 'gdpr', server: false }
+    ],
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css
     css: ['app.sass'],
@@ -75,6 +79,9 @@ module.exports = function (ctx) {
             formatter: require('eslint').CLIEngine.getFormatter('stylish')
           }
         })
+      },
+      uglifyOptions: {
+        compress: { drop_console: true }
       }
     },
 


### PR DESCRIPTION
Configures quasar build process to strip all `console` calls from the code.

(refs #13)